### PR TITLE
ci: update CI workflow to include Python 3.14 and improve coverage re…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,30 @@ jobs:
       - run: pipx run check-manifest
 
   test:
-    uses: pyapp-kit/workflows/.github/workflows/test-pyrepo.yml@v2
-    with:
-      os: ${{ matrix.platform }}
-      python-version: ${{ matrix.python-version }}
-      coverage-upload: artifact
+    name: Test
+    runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        platform: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest]
+        resolution: ["highest", "lowest-direct"]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v7
+      - run: uv run --group test coverage run -p -m pytest -v --color=yes
+        env:
+          UV_NO_DEV: "1"
+          UV_RESOLUTION: ${{ matrix.resolution }}
+          PYTEST_ADDOPTS: ${{ matrix.resolution == 'lowest-direct' && '-W ignore' || '' }}
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v5
+        with:
+          name: covreport-${{ matrix.os }}-py${{ matrix.python-version }}-${{ matrix.resolution }}
+          path: ./.coverage*
+          include-hidden-files: true
 
   upload_coverage:
     if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ ENV/
 # IDE settings
 .vscode/
 .idea/
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,6 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 
-# read more about configuring hatch at:
-# https://hatch.pypa.io/latest/config/build/
-[tool.hatch.build.targets.wheel]
-only-include = ["src"]
-sources = ["src"]
 
 # https://peps.python.org/pep-0621/
 [project]
@@ -31,22 +26,27 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
-dependencies = ['pydantic', 'requests']
+dependencies = ["pydantic>=2.8", "requests>=2.31"]
 
-# https://peps.python.org/pep-0621/#dependencies-optional-dependencies
-[project.optional-dependencies]
-test = ["pytest", "pytest-cov"]
-dev = [
-    "ipython",
-    "types-requests",
-    "mypy",
-    "pdbpp",          # https://github.com/pdbpp/pdbpp
-    "pre-commit",
-    "rich",           # https://github.com/Textualize/rich
-    "ruff",
+[dependency-groups]
+test = [
+    "pytest>=8.4.2",
+    "pytest-cov>=7.0.0",
 ]
+dev = [
+    { include-group = "test" },
+    "ipython>=8.18.1",
+    "mypy>=1.19.0",
+    "pdbpp>=0.11.7",
+    "pre-commit>=4.3.0",
+    "rich>=14.2.0",
+    "ruff>=0.14.7",
+    "types-requests>=2.32.4.20250913",
+]
+
 
 [project.urls]
 homepage = "https://github.com/tlambert03/fpbasepy"


### PR DESCRIPTION
…porting

chore: add uv.lock to .gitignore
fix: refine dependencies in pyproject.toml and update optional dependencies